### PR TITLE
Update docker-compose: version bump and exposing ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,9 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=membrane_timescaledb_reporter
     command: ["-c", "max_connections=100"]
-  
+
   dashboard:
-    image: membraneframeworklabs/membrane_dashboard
+    image: membraneframeworklabs/membrane_dashboard:v0.3.0
     ports:
       - 8000:8000
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: timescale/timescaledb:1.7.4-pg12
     ports:
       - 5432:5432
+    expose:
+      - "5432"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
@@ -14,6 +16,8 @@ services:
     image: membraneframeworklabs/membrane_dashboard
     ports:
       - 8000:8000
+    expose:
+      - "8000"
     environment:
       - DB_USER=postgres
       - DB_PASS=postgres


### PR DESCRIPTION
- Expose ports of dashboard services to the running host
- Pin to latest version of membrane_dashboard